### PR TITLE
Fix rendering when tracks source_range is in play

### DIFF
--- a/timeline.cpp
+++ b/timeline.cpp
@@ -284,7 +284,7 @@ void DrawEffects(otio::Item* item, float scale, ImVec2 origin, float row_height,
         Log("Couldn't find %s in range map?!", item->name().c_str());
         assert(false);
     }
-    auto item_range = range_it->second;    
+    auto item_range = TopLevelTimeRange(range_it->second, item->parent());
 
     ImVec2 size(width, height);
     float item_x = item_range.start_time().to_seconds() * scale + origin.x;


### PR DESCRIPTION
This PR aims to fix the timeline rendering to correctly display items at the right location when a Track's source_range is set. Without this fix, a Track's source_range is not honored, and the display is incorrect.