### PR TITLE
Various changes for building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set_property(TARGET raven PROPERTY CXX_STANDARD 14)
 
 add_subdirectory("imgui")
 
-find_package(glfw3)
 include(glfw.cmake)
 
 target_sources(raven

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ include(glfw.cmake)
 
 target_sources(raven
   PUBLIC
+    app.h
+    editing.h
+    inspector.h
+    timeline.h
+    widgets.h
+
     main_glfw.cpp
     app.cpp
     editing.cpp
@@ -26,6 +32,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/libs/nativefiledialog/src/include
 )
 
+set(OTIO_SHARED_LIBS OFF)
 add_subdirectory("libs/opentimelineio")
 include_directories(
   ${PROJECT_SOURCE_DIR}/libs/opentimelineio/src

--- a/editing.cpp
+++ b/editing.cpp
@@ -200,7 +200,7 @@ void FlattenTrackDown() {
   tracks.push_back(track_below);
   tracks.push_back(selected_track);
   auto flat_track = otio::flatten_stack(tracks, &error_status);
-  if (!flat_track or is_error(error_status)) {
+  if (!flat_track || is_error(error_status)) {
     Message("Cannot flatten: %s.", otio_error_string(error_status).c_str());
     return;
   }

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(SET CMP0072 NEW)
 cmake_policy(SET CMP0076 NEW)
 
 find_package(OpenGL REQUIRED)

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_policy(SET CMP0076 NEW)
 
+find_package(OpenGL REQUIRED)
+
 add_library(IMGUI STATIC)
 
 set_property(TARGET IMGUI PROPERTY CXX_STANDARD 11)
@@ -27,6 +29,6 @@ target_include_directories(IMGUI
   PUBLIC ../libs/gl3w
   PUBLIC ../libs/glfw/include/
 )
-
+target_link_libraries(IMGUI OpenGL::GL ${CMAKE_DL_LIBS})
 target_compile_definitions(IMGUI PUBLIC -DIMGUI_IMPL_OPENGL_LOADER_GL3W)
 

--- a/imgui/imguihelper.cpp
+++ b/imgui/imguihelper.cpp
@@ -8,6 +8,13 @@
 #include "imguihelper.h"
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #include <shellapi.h>	// ShellExecuteA(...) - Shell32.lib
 #include <objbase.h>    // CoInitializeEx(...)  - ole32.lib
 #else //_WIN32

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,23 +1,30 @@
 cmake_policy(SET CMP0076 NEW)
 
+if(UNIX)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+endif()
+
 add_library(nativefiledialog STATIC)
 
 set_property(TARGET nativefiledialog PROPERTY CXX_STANDARD 11)
 
 set(SOURCES nativefiledialog/src/nfd_common.c)
+set(INCLUDE_DIRS nativefiledialog/src nativefiledialog/src/include)
+set(LIBRARIES)
 if(APPLE)
     list(APPEND SOURCES nativefiledialog/src/nfd_cocoa.m)
 elseif(WIN32)
     list(APPEND SOURCES nativefiledialog/src/nfd_win.cpp)
-else()
+elseif(UNIX)
     list(APPEND SOURCES nativefiledialog/src/nfd_gtk.c)
+    list(APPEND INCLUDE_DIRS ${GTK3_INCLUDE_DIRS})
+    list(APPEND LIBRARIES ${GTK3_LIBRARIES})
 endif()
 
 target_sources(nativefiledialog PRIVATE ${SOURCES})
-target_include_directories(nativefiledialog
-  PUBLIC nativefiledialog/src
-  PUBLIC nativefiledialog/src/include
-)
+target_include_directories(nativefiledialog PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(nativefiledialog PRIVATE ${LIBRARIES})
 
 # target_compile_definitions(nativefiledialog PUBLIC -DIMGUI_IMPL_OPENGL_LOADER_GL3W)
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -4,11 +4,16 @@ add_library(nativefiledialog STATIC)
 
 set_property(TARGET nativefiledialog PROPERTY CXX_STANDARD 11)
 
-target_sources(nativefiledialog
-  PRIVATE
-    nativefiledialog/src/nfd_cocoa.m
-    nativefiledialog/src/nfd_common.c
-)
+set(SOURCES nativefiledialog/src/nfd_common.c)
+if(APPLE)
+    list(APPEND SOURCES nativefiledialog/src/nfd_cocoa.m)
+elseif(WIN32)
+    list(APPEND SOURCES nativefiledialog/src/nfd_win.cpp)
+else()
+    list(APPEND SOURCES nativefiledialog/src/nfd_gtk.c)
+endif()
+
+target_sources(nativefiledialog PRIVATE ${SOURCES})
 target_include_directories(nativefiledialog
   PUBLIC nativefiledialog/src
   PUBLIC nativefiledialog/src/include

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_policy(SET CMP0076 NEW)
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 endif()


### PR DESCRIPTION
Signed-off-by: Darby Johnston <darbyjohnston@yahoo.com>

Hi, I was trying to compile on Windows with Visual Studio and ran into a couple of issues. Here are some suggestions for changes that fixed them:

* Add Raven header files to the CMakeLists.txt so they appear in the Visual Studio IDE.
* Build OTIO as a static library to make running the application a bit easier (no runtime library paths to setup).
* Use ```||``` instead of ```or``` to make MSVC happy (or a define could be added instead).
* Link imgui with OpenGL (is the imgui CMakeLists.txt something you created?).
* Add ```windows.h``` to imguihelper.cpp (is this file part of imgui or something that was added?).
* Add platform specific sources for nativefiledialog.
