### PR TITLE
Fix icons on MSVC and remove deprecated function 

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -757,7 +757,7 @@ void DrawToolbar(ImVec2 button_size) {
 #ifdef SHOW_FPS
     // skip to the far right edge
     ImGui::SameLine();
-    ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvailWidth() - 250, 5));
+    ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x; - 250, 5));
 
     int fps = rint(1.0f / ImGui::GetIO().DeltaTime);
     ImGui::PushStyleColor(

--- a/app.cpp
+++ b/app.cpp
@@ -69,6 +69,8 @@ std::string Format(const char* format, ...) {
 // automatically (on iOS/Android/Emscripten), but that's not wired up.
 bool LoadFonts(const std::string& resourcePath) {
     ImGuiIO& io = ImGui::GetIO();
+    ImFontConfig config;
+    config.MergeMode = true;
 
     // TODO: Use ImGuiFontStudio to bundle these fonts into the executable?
 #ifdef EMSCRIPTEN
@@ -80,7 +82,7 @@ bool LoadFonts(const std::string& resourcePath) {
     gTechFont = io.Fonts->AddFontFromFileTTF(path.c_str(), 20.0f);
     static const ImWchar icon_fa_ranges[] = { 0xF000, 0xF18B, 0 };
     path = resourcePath + "fontawesome-webfont.ttf";
-    gIconFont = io.Fonts->AddFontFromFileTTF(path.c_str(), 16.0f, NULL, icon_fa_ranges);
+    gIconFont = io.Fonts->AddFontFromFileTTF(path.c_str(), 16.0f, &config, icon_fa_ranges);
 #endif
 
     return gTechFont != nullptr && gIconFont != nullptr;
@@ -709,17 +711,17 @@ void DrawMenu() {
 void DrawToolbar(ImVec2 button_size) {
     // ImGuiStyle& style = ImGui::GetStyle();
 
-    if (IconButton("\uF014##Delete", button_size)) {
+    if (IconButton("\xef\x80\x94##Delete", button_size)) {
         DeleteSelectedObject();
     }
 
     ImGui::SameLine();
-    if (IconButton("\uF02B##Mark", button_size)) {
+    if (IconButton("\xef\x80\xab##Mark", button_size)) {
         AddMarkerAtPlayhead();
     }
 
     ImGui::SameLine();
-    if (IconButton("\uF03C +Track", ImVec2(0, button_size.y))) {
+    if (IconButton("\xef\x80\xbc +Track", ImVec2(0, button_size.y))) {
         AddTrack();
     }
 
@@ -733,7 +735,7 @@ void DrawToolbar(ImVec2 button_size) {
         ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
     ImGui::PushFont(gIconFont);
     ImGui::SameLine();
-    ImGui::Text("\uF05A"); // (i) icon
+    ImGui::Text("\xef\x81\x9a"); // (i) icon
     ImGui::PopFont();
     ImGui::PopStyleColor();
     ImGui::SameLine();
@@ -765,7 +767,7 @@ void DrawToolbar(ImVec2 button_size) {
         ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
     ImGui::PushFont(gIconFont);
     ImGui::SameLine();
-    ImGui::Text("\uF0E4"); // dashboard meter icon
+    ImGui::Text("\xef\x83\xa4"); // dashboard meter icon
     ImGui::PopFont();
     ImGui::PopStyleColor();
     ImGui::SameLine();

--- a/timeline.cpp
+++ b/timeline.cpp
@@ -569,7 +569,7 @@ void DrawMarkers(
 }
 
 void DrawObjectLabel(otio::SerializableObjectWithMetadata* object, float height) {
-    float width = ImGui::GetContentRegionAvailWidth();
+    float width = ImGui::GetContentRegionAvail().x;
 
     ImGui::BeginGroup();
     ImGui::AlignTextToFramePadding();
@@ -618,7 +618,7 @@ void DrawObjectLabel(otio::SerializableObjectWithMetadata* object, float height)
 }
 
 void DrawTrackLabel(otio::Track* track, int index, float height) {
-    float width = ImGui::GetContentRegionAvailWidth();
+    float width = ImGui::GetContentRegionAvail().x;
 
     ImGui::BeginGroup();
     ImGui::AlignTextToFramePadding();
@@ -864,7 +864,7 @@ bool DrawTimecodeTrack(
     bool interactive = true) {
     bool moved_playhead = false;
 
-    float width = ImGui::GetContentRegionAvailWidth();
+    float width = ImGui::GetContentRegionAvail().x;
     ImVec2 size(fmaxf(full_width, width), track_height);
 
     auto old_pos = ImGui::GetCursorPos();
@@ -1229,7 +1229,7 @@ void DrawTrackSplitter(const char* str_id, float splitter_size) {
     int num_tracks_above = ImGui::TableGetRowIndex();
     float sz1 = 0;
     float sz2 = 0;
-    float width = ImGui::GetContentRegionAvailWidth();
+    float width = ImGui::GetContentRegionAvail().x;
     float sz1_min = -(appState.track_height - 25.0f) * num_tracks_above;
     if (Splitter(
             str_id,


### PR DESCRIPTION
Here are some small fixes. The icons don't work at all for me when I compile with MSVC.  
![before_crop](https://user-images.githubusercontent.com/814966/201437040-f8bce577-cf34-484b-a29e-44fded60fb2a.png)
MSVC doesn't seem to like the Universal character `\U` encoding in strings. There are multiple ways to handle this issue

https://learn.microsoft.com/en-us/cpp/cpp/string-and-character-literals-cpp?view=msvc-170

I choose to use hex encoding, I think its the most portable and supports the most C++ versions.  Another option that worked for me was using `u8` literal prefixes, but I think that would require C++20 or greater. 

I'm not sure if it was intentional but "+Track" text was getting lost, I merged the fonts to solve this issue. This allows the icon font use text too.

![fixed_crop](https://user-images.githubusercontent.com/814966/201437408-cfa8b158-9ae5-4a85-9bd8-21e95c5d9c98.png)

Also I've been experimenting with upgrading IMGUI to the latest version and `ImGui::GetContentRegionAvailWidth()` has been removed. The docs say to use `ImGui::GetContentRegionAvail().x` instead.

